### PR TITLE
Made to work with Java 8

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,13 @@ suites:
       karaf_test:
         version: '4.0.4'
 
+  - name: default-407
+    run_list:
+      - recipe[karaf_test::install]
+    attributes:
+      karaf_test:
+        version: '4.0.7'
+
   - name: default-305
     run_list:
       - recipe[karaf_test::install]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 * ark cookbook
 
 ### Platform
-* Tested on CentOS 6.6 and Ubuntu 14.04 (via Kitchen)
+* Tested on CentOS 6.6, CentOS 7.2 and Ubuntu 14.04 (via Kitchen)
 
 ## Resources
 
@@ -20,7 +20,7 @@ Requirements
 ```ruby
 karaf 'install karaf' do
   install_java  true
-  version       '4.0.4'
+  version       '4.0.7'
   user         'someuser'  
   action        :install
 end
@@ -155,6 +155,7 @@ Known Issues
 ------------
 The service wrapper component does not reliably install, depending on the version of Karaf and Centos.
 
+* 4.0.7 - works fine with Java 8
 * 4.0.4 - works fine
 * 3.0.6 (and above?) - Not working
 * 3.0.5 - Supports systemd, WORKS FINE

--- a/resources/karaf.rb
+++ b/resources/karaf.rb
@@ -79,6 +79,15 @@ action :install do
 	not_if       "bin/client -u karaf 'feature:list -i' | grep -v grep | grep service-wrapper -c"
   end
   
+  ruby_block 'comment karaf user key' do
+    block do
+      fe = Chef::Util::FileEdit.new("#{karaf_path}/#{keys_file}")
+      fe.search_file_replace(/karaf=/, "#karaf=")
+      fe.write_file
+    end
+    only_if { ::File.readlines("#{karaf_path}/#{keys_file}").grep(/karaf=/).any? }
+  end
+  
   ruby_block 'modify user that karaf runs as' do
     block do
       fe = Chef::Util::FileEdit.new("#{karaf_path}/#{service_wrapper_file}")

--- a/test/cookbooks/karaf_test/attributes/default.rb
+++ b/test/cookbooks/karaf_test/attributes/default.rb
@@ -1,2 +1,2 @@
 
-default['karaf_test']['version'] = '4.0.4'
+default['karaf_test']['version'] = '4.0.7'

--- a/test/cookbooks/karaf_test/attributes/java.rb
+++ b/test/cookbooks/karaf_test/attributes/java.rb
@@ -1,4 +1,4 @@
 default['java']['install_flavor'] = 'oracle'
-default['java']['jdk_version'] = '7'
+default['java']['jdk_version'] = '8'
 default['java']['set_etc_environment'] = true
 default['java']['oracle']['accept_oracle_download_terms'] = true

--- a/test/integration/slow-cloud/serverspec/karaf_install_retry_spec.rb
+++ b/test/integration/slow-cloud/serverspec/karaf_install_retry_spec.rb
@@ -1,6 +1,0 @@
-require 'serverspec'
-set :backend, :exec
-
-describe file('/tmp/karaf-install.log') do
-  its(:content) { should match(/Command not found: feature:install/) }
-end


### PR DESCRIPTION
For Karaf 8 to work with Java 8, I needed to comment out the karaf user key in the etc/keys.properties file so that the karaf client can now authenticate with the karaf service.

I also refactored the big batch command into separate chef command calls that have built in retry logic with chef. By doing this I also had to remove the test that checks the log file for the retry messages since now the retries are silent.

All tests pass except for the test that tests Karaf 3.0.3 because Karaf has to run under SysV it seems like and when verifying it looks like Chef cannot see that the service is running, even though I checked on the machine and it is running.