### PR TITLE
Add auto start flag to bundle install command

### DIFF
--- a/resources/karaf_bundle.rb
+++ b/resources/karaf_bundle.rb
@@ -26,8 +26,6 @@ action :install do
 
   bash 'install bundle' do
     cwd  karaf_path
-    code <<-EOH
-      #{client_command} bundle:install #{bundle_string}
-    EOH
+    code "#{client_command} bundle:install #{bundle_string}"
   end
 end

--- a/resources/karaf_bundle.rb
+++ b/resources/karaf_bundle.rb
@@ -26,6 +26,6 @@ action :install do
 
   bash 'install bundle' do
     cwd  karaf_path
-    code "#{client_command} bundle:install #{bundle_string}"
+    code "#{client_command} bundle:install -s #{bundle_string}"
   end
 end

--- a/resources/karaf_feature.rb
+++ b/resources/karaf_feature.rb
@@ -20,8 +20,6 @@ action :install do
 
   bash 'install feature' do
     cwd  karaf_path
-    code <<-EOH
-      #{client_command} feature:install #{feature_string}
-    EOH
+    code "#{client_command} feature:install #{feature_string}"
   end
 end

--- a/resources/karaf_feature_repository.rb
+++ b/resources/karaf_feature_repository.rb
@@ -15,8 +15,6 @@ end
 action :install do
   bash 'install feature repo' do
     cwd  karaf_path
-    code <<-EOH
-      #{client_command} feature:repo-add #{repository_name} #{version}
-    EOH
+    code "#{client_command} feature:repo-add #{repository_name} #{version}"
   end
 end


### PR DESCRIPTION
The -s flag starts the bundle right away after installing, this means you will not have to manually start each bundle after installing.